### PR TITLE
fix(ds18b20): add CRC verification and 85°C POR retry logic

### DIFF
--- a/src/temp_sensor/logic.rs
+++ b/src/temp_sensor/logic.rs
@@ -4,10 +4,30 @@ pub fn ds18b20_raw_to_celsius(lsb: u8, msb: u8) -> f32 {
     f32::from(temp_raw) / 16.0
 }
 
+/// Dallas 1-Wire CRC-8 (poly=0x31, LSB-first)
+///
+/// DS18B20 scratchpad の整合性検証に使用。scratch[0..8] の CRC が scratch[8] と一致すること。
+pub fn compute_crc8(data: &[u8]) -> u8 {
+    let mut crc = 0u8;
+    for &byte in data {
+        let mut b = byte;
+        for _ in 0..8 {
+            if (crc ^ b) & 0x01 != 0 {
+                crc = (crc >> 1) ^ 0x8C;
+            } else {
+                crc >>= 1;
+            }
+            b >>= 1;
+        }
+    }
+    crc
+}
+
 #[cfg(test)]
 #[cfg(not(any(target_arch = "riscv32", target_arch = "xtensa")))]
 mod tests {
     use super::*;
+
     #[test]
     fn test_positive() {
         assert!((ds18b20_raw_to_celsius(0x91, 0x01) - 25.0625).abs() < 0.001);
@@ -19,5 +39,30 @@ mod tests {
     #[test]
     fn test_zero() {
         assert_eq!(ds18b20_raw_to_celsius(0x00, 0x00), 0.0);
+    }
+
+    #[test]
+    fn test_crc8_empty() {
+        assert_eq!(compute_crc8(&[]), 0x00);
+    }
+
+    #[test]
+    fn test_crc8_appended_gives_zero() {
+        // Dallas 1-Wire CRC property: CRC over data[0..n] + CRC_byte == 0x00
+        let data: [u8; 8] = [0x50, 0x05, 0x4B, 0x46, 0x7F, 0xFF, 0x0C, 0x10];
+        let crc = compute_crc8(&data);
+        let mut full = data.to_vec();
+        full.push(crc);
+        assert_eq!(compute_crc8(&full), 0x00);
+    }
+
+    #[test]
+    fn test_crc8_corrupt_detected() {
+        let data: [u8; 8] = [0x50, 0x05, 0x4B, 0x46, 0x7F, 0xFF, 0x0C, 0x10];
+        let crc = compute_crc8(&data);
+        // Flip one bit in data — CRC should differ
+        let mut corrupt = data;
+        corrupt[0] ^= 0x01;
+        assert_ne!(compute_crc8(&corrupt), crc);
     }
 }

--- a/src/temp_sensor/logic.rs
+++ b/src/temp_sensor/logic.rs
@@ -4,7 +4,7 @@ pub fn ds18b20_raw_to_celsius(lsb: u8, msb: u8) -> f32 {
     f32::from(temp_raw) / 16.0
 }
 
-/// Dallas 1-Wire CRC-8 (poly=0x31, LSB-first)
+/// Dallas 1-Wire CRC-8 (polynomial 0x31 = x^8+x^5+x^4+1, processed LSB-first using reflected constant 0x8C)
 ///
 /// DS18B20 scratchpad の整合性検証に使用。scratch[0..8] の CRC が scratch[8] と一致すること。
 pub fn compute_crc8(data: &[u8]) -> u8 {
@@ -39,6 +39,25 @@ mod tests {
     #[test]
     fn test_zero() {
         assert_eq!(ds18b20_raw_to_celsius(0x00, 0x00), 0.0);
+    }
+
+    #[test]
+    fn test_crc8_known_vector() {
+        // Fixed expected values computed from the Dallas 1-Wire CRC-8 algorithm.
+        // These pin the polynomial/reflection so any regression is immediately visible.
+        // compute_crc8(&[0x01]) = 0x5E, compute_crc8(&[0x02]) = 0xBC
+        assert_eq!(compute_crc8(&[0x01]), 0x5E);
+        assert_eq!(compute_crc8(&[0x02]), 0xBC);
+        // 25.0625°C scratchpad bytes 0..7: [0x91,0x01,0x4B,0x46,0x7F,0xFF,0x0C,0x10] → CRC 0x70
+        assert_eq!(
+            compute_crc8(&[0x91, 0x01, 0x4B, 0x46, 0x7F, 0xFF, 0x0C, 0x10]),
+            0x70
+        );
+        // POR scratchpad bytes 0..7 (temp=85°C): [0x50,0x05,0x4B,0x46,0x7F,0xFF,0x0C,0x10] → CRC 0x1C
+        assert_eq!(
+            compute_crc8(&[0x50, 0x05, 0x4B, 0x46, 0x7F, 0xFF, 0x0C, 0x10]),
+            0x1C
+        );
     }
 
     #[test]

--- a/src/temp_sensor/logic.rs
+++ b/src/temp_sensor/logic.rs
@@ -6,7 +6,7 @@ pub fn ds18b20_raw_to_celsius(lsb: u8, msb: u8) -> f32 {
 
 /// Dallas 1-Wire CRC-8 (polynomial 0x31 = x^8+x^5+x^4+1, processed LSB-first using reflected constant 0x8C)
 ///
-/// DS18B20 scratchpad の整合性検証に使用。scratch[0..8] の CRC が scratch[8] と一致すること。
+/// DS18B20 scratchpad の整合性検証に使用。先頭 8 バイト (byte 0〜7) の CRC が byte[8] と一致すること。
 pub fn compute_crc8(data: &[u8]) -> u8 {
     let mut crc = 0u8;
     for &byte in data {

--- a/src/temp_sensor/mod.rs
+++ b/src/temp_sensor/mod.rs
@@ -1,8 +1,8 @@
 pub mod logic; // Declares src/temp_sensor/logic.rs
 
 #[cfg(any(target_arch = "riscv32", target_arch = "xtensa"))]
-pub mod temp_sensor; // Declares src/temp_sensor/temp_sensor.rs
+mod sensor; // Declares src/temp_sensor/sensor.rs
 
 // Re-export TempSensor struct so it can be used as `crate::temp_sensor::TempSensor`
 #[cfg(any(target_arch = "riscv32", target_arch = "xtensa"))]
-pub use self::temp_sensor::TempSensor;
+pub use self::sensor::TempSensor;

--- a/src/temp_sensor/sensor.rs
+++ b/src/temp_sensor/sensor.rs
@@ -47,20 +47,18 @@ impl TempSensor {
 
     fn search_device(&mut self) -> Result<OWAddress, EspError> {
         let mut addr = None;
-        for dev in self.onewire_bus.search()? {
-            if let Ok(a) = dev {
-                if a.family_code() == 0x28 {
-                    addr = Some(a);
-                    break;
-                }
+        for a in self.onewire_bus.search()?.flatten() {
+            if a.family_code() == 0x28 {
+                addr = Some(a);
+                break;
             }
         }
-        addr.ok_or_else(|| EspError::from(esp_idf_sys::ESP_ERR_NOT_FOUND as i32).unwrap())
+        addr.ok_or_else(|| EspError::from(esp_idf_sys::ESP_ERR_NOT_FOUND).unwrap())
     }
 
     pub fn read_temperature(&mut self) -> Result<f32, EspError> {
         const MAX_RETRIES: u8 = 3;
-        let mut last_err = EspError::from(esp_idf_sys::ESP_ERR_INVALID_RESPONSE as i32).unwrap();
+        let mut last_err = EspError::from(esp_idf_sys::ESP_ERR_INVALID_RESPONSE).unwrap();
 
         for attempt in 0..MAX_RETRIES {
             if attempt > 0 {
@@ -156,7 +154,7 @@ impl TempSensor {
                     MAX_RETRIES,
                     scratch
                 );
-                last_err = EspError::from(esp_idf_sys::ESP_ERR_INVALID_CRC as i32).unwrap();
+                last_err = EspError::from(esp_idf_sys::ESP_ERR_INVALID_CRC).unwrap();
                 continue;
             }
 
@@ -173,7 +171,7 @@ impl TempSensor {
                     attempt + 1,
                     MAX_RETRIES
                 );
-                last_err = EspError::from(esp_idf_sys::ESP_ERR_INVALID_RESPONSE as i32).unwrap();
+                last_err = EspError::from(esp_idf_sys::ESP_ERR_INVALID_RESPONSE).unwrap();
                 continue;
             }
 

--- a/src/temp_sensor/sensor.rs
+++ b/src/temp_sensor/sensor.rs
@@ -47,13 +47,20 @@ impl TempSensor {
 
     fn search_device(&mut self) -> Result<OWAddress, EspError> {
         let mut addr = None;
-        for a in self.onewire_bus.search()?.flatten() {
-            if a.family_code() == 0x28 {
-                addr = Some(a);
-                break;
+        let mut last_bus_err: Option<EspError> = None;
+        for dev in self.onewire_bus.search()? {
+            match dev {
+                Ok(a) if a.family_code() == 0x28 => {
+                    addr = Some(a);
+                    break;
+                }
+                Ok(_) => {}
+                Err(e) => last_bus_err = Some(e),
             }
         }
-        addr.ok_or_else(|| EspError::from(esp_idf_sys::ESP_ERR_NOT_FOUND).unwrap())
+        addr.ok_or_else(|| {
+            last_bus_err.unwrap_or_else(|| EspError::from(esp_idf_sys::ESP_ERR_NOT_FOUND).unwrap())
+        })
     }
 
     pub fn read_temperature(&mut self) -> Result<f32, EspError> {

--- a/src/temp_sensor/temp_sensor.rs
+++ b/src/temp_sensor/temp_sensor.rs
@@ -1,4 +1,4 @@
-use crate::temp_sensor::logic::ds18b20_raw_to_celsius;
+use crate::temp_sensor::logic::{compute_crc8, ds18b20_raw_to_celsius};
 use anyhow::Result;
 use esp_idf_svc::hal::delay::FreeRtos;
 use esp_idf_svc::hal::gpio::{AnyIOPin, AnyOutputPin, Output, PinDriver};
@@ -6,6 +6,7 @@ use esp_idf_svc::hal::onewire::{OWAddress, OWCommand, OWDriver};
 use esp_idf_svc::hal::peripheral::Peripheral;
 use esp_idf_svc::hal::rmt::RmtChannel;
 use esp_idf_sys::EspError;
+use log::warn;
 
 pub struct TempSensor {
     power_pin: PinDriver<'static, AnyOutputPin, Output>,
@@ -15,24 +16,24 @@ pub struct TempSensor {
 
 impl TempSensor {
     /// 外部Peripherals管理でTempSensorを作成（推奨API）
-    /// 
+    ///
     /// # Arguments
     /// * `power_pin_num` - 電源制御用GPIOピン番号
     /// * `data_pin_num` - データピン番号
     /// * `rmt_channel` - RMTチャンネル
-    /// 
+    ///
     /// # Example
     /// ```no_run
     /// use esp_idf_svc::hal::peripherals::Peripherals;
     /// use simple_ds18b20_temp_sensor::TempSensor;
-    /// 
+    ///
     /// let peripherals = Peripherals::take().unwrap();
     /// let mut temp_sensor = TempSensor::new(2, 3, peripherals.rmt.channel0)?;
     /// let temperature = temp_sensor.read_temperature()?;
     /// ```
     pub fn new<C: esp_idf_svc::hal::rmt::RmtChannel>(
-        power_pin_num: i32, 
-        data_pin_num: i32, 
+        power_pin_num: i32,
+        data_pin_num: i32,
         rmt_channel: impl Peripheral<P = C> + 'static
     ) -> Result<Self> {
         let power_pin = PinDriver::output(unsafe { AnyOutputPin::new(power_pin_num) })?;
@@ -62,44 +63,101 @@ impl TempSensor {
     }
 
     pub fn read_temperature(&mut self) -> Result<f32, EspError> {
-        // 電源ON
-        self.power_pin.set_high()?;
-        FreeRtos::delay_ms(500);
+        const MAX_RETRIES: u8 = 3;
+        let mut last_err = EspError::from(esp_idf_sys::ESP_ERR_INVALID_RESPONSE as i32).unwrap();
 
-        // デバイスアドレス検索
-        let addr = match self.device_address {
-            Some(a) => a,
-            None => {
-                let found = self.search_device()?;
-                self.device_address = Some(found);
-                found
+        for attempt in 0..MAX_RETRIES {
+            if attempt > 0 {
+                // リトライ前にパワーサイクルしてデバイスをリセット
+                self.power_pin.set_low()?;
+                FreeRtos::delay_ms(50);
+                self.device_address = None; // 再検索を強制
             }
-        };
 
-        // 温度変換コマンド送信
-        self.onewire_bus.reset()?;
-        let mut buf = [0; 10];
-        buf[0] = OWCommand::MatchRom as _;
-        let addr_bytes = addr.address().to_le_bytes();
-        buf[1..9].copy_from_slice(&addr_bytes);
-        buf[9] = 0x44; // ConvertTemp
-        self.onewire_bus.write(&buf)?;
-        FreeRtos::delay_ms(800);
+            self.power_pin.set_high()?;
+            FreeRtos::delay_ms(500);
 
-        // Scratchpad読み出し
-        self.onewire_bus.reset()?;
-        buf[9] = 0xBE; // ReadScratch
-        self.onewire_bus.write(&buf)?;
-        let mut scratch = [0u8; 9];
-        self.onewire_bus.read(&mut scratch)?;
+            let addr = match self.device_address {
+                Some(a) => a,
+                None => match self.search_device() {
+                    Ok(a) => {
+                        self.device_address = Some(a);
+                        a
+                    }
+                    Err(e) => {
+                        warn!("DS18B20 search failed (attempt {}/{})", attempt + 1, MAX_RETRIES);
+                        last_err = e;
+                        continue;
+                    }
+                },
+            };
 
-        let lsb = scratch[0];
-        let msb = scratch[1];
-        let temp = ds18b20_raw_to_celsius(lsb, msb);
+            // 温度変換コマンド送信
+            if let Err(e) = self.onewire_bus.reset() {
+                warn!("1-Wire reset failed (attempt {}/{})", attempt + 1, MAX_RETRIES);
+                last_err = e;
+                continue;
+            }
+            let mut buf = [0u8; 10];
+            buf[0] = OWCommand::MatchRom as _;
+            buf[1..9].copy_from_slice(&addr.address().to_le_bytes());
+            buf[9] = 0x44; // ConvertTemp
+            if let Err(e) = self.onewire_bus.write(&buf) {
+                warn!("ConvertTemp failed (attempt {}/{})", attempt + 1, MAX_RETRIES);
+                last_err = e;
+                continue;
+            }
+            FreeRtos::delay_ms(800);
 
-        // 電源OFF
-        self.power_pin.set_low()?;
+            // Scratchpad読み出し
+            if let Err(e) = self.onewire_bus.reset() {
+                warn!("1-Wire reset failed (attempt {}/{})", attempt + 1, MAX_RETRIES);
+                last_err = e;
+                continue;
+            }
+            buf[9] = 0xBE; // ReadScratchpad
+            if let Err(e) = self.onewire_bus.write(&buf) {
+                warn!("ReadScratch failed (attempt {}/{})", attempt + 1, MAX_RETRIES);
+                last_err = e;
+                continue;
+            }
+            let mut scratch = [0u8; 9];
+            if let Err(e) = self.onewire_bus.read(&mut scratch) {
+                warn!("Scratchpad read failed (attempt {}/{})", attempt + 1, MAX_RETRIES);
+                last_err = e;
+                continue;
+            }
 
-        Ok(temp)
+            // CRC検証: DS18B20 scratchpad[8] は scratchpad[0..8] のCRC
+            if compute_crc8(&scratch[0..8]) != scratch[8] {
+                warn!(
+                    "DS18B20 CRC mismatch on attempt {}/{}: scratch={:02X?}",
+                    attempt + 1,
+                    MAX_RETRIES,
+                    scratch
+                );
+                last_err = EspError::from(esp_idf_sys::ESP_ERR_INVALID_CRC as i32).unwrap();
+                continue;
+            }
+
+            let temp = ds18b20_raw_to_celsius(scratch[0], scratch[1]);
+
+            // 85°C は DS18B20 の電源ON時デフォルト値（POR）。変換未完了または電源不安定を示す
+            if (temp - 85.0_f32).abs() < 0.01 {
+                warn!(
+                    "DS18B20 returned POR default (85.0°C) on attempt {}/{}",
+                    attempt + 1,
+                    MAX_RETRIES
+                );
+                last_err = EspError::from(esp_idf_sys::ESP_ERR_INVALID_RESPONSE as i32).unwrap();
+                continue;
+            }
+
+            self.power_pin.set_low()?;
+            return Ok(temp);
+        }
+
+        let _ = self.power_pin.set_low();
+        Err(last_err)
     }
 }

--- a/src/temp_sensor/temp_sensor.rs
+++ b/src/temp_sensor/temp_sensor.rs
@@ -142,7 +142,11 @@ impl TempSensor {
 
             let temp = ds18b20_raw_to_celsius(scratch[0], scratch[1]);
 
-            // 85°C は DS18B20 の電源ON時デフォルト値（POR）。変換未完了または電源不安定を示す
+            // 85°C は DS18B20 の電源ON時デフォルト値（POR）。変換未完了または電源不安定を示す。
+            // NOTE: DS18B20 の測定範囲は -55〜+125°C なので、農業・室内環境での実測 85°C は
+            // 現実的でなく POR と見なして差し支えない。85°C が実際に現れる環境では、
+            // scratchpad byte2〜4（TH/TL/Config）を POR デフォルト値と比較することで
+            // 誤検出を低減できる（将来の拡張ポイント）。
             if (temp - 85.0_f32).abs() < 0.01 {
                 warn!(
                     "DS18B20 returned POR default (85.0°C) on attempt {}/{}",

--- a/src/temp_sensor/temp_sensor.rs
+++ b/src/temp_sensor/temp_sensor.rs
@@ -4,7 +4,6 @@ use esp_idf_svc::hal::delay::FreeRtos;
 use esp_idf_svc::hal::gpio::{AnyIOPin, AnyOutputPin, Output, PinDriver};
 use esp_idf_svc::hal::onewire::{OWAddress, OWCommand, OWDriver};
 use esp_idf_svc::hal::peripheral::Peripheral;
-use esp_idf_svc::hal::rmt::RmtChannel;
 use esp_idf_sys::EspError;
 use log::warn;
 
@@ -34,13 +33,10 @@ impl TempSensor {
     pub fn new<C: esp_idf_svc::hal::rmt::RmtChannel>(
         power_pin_num: i32,
         data_pin_num: i32,
-        rmt_channel: impl Peripheral<P = C> + 'static
+        rmt_channel: impl Peripheral<P = C> + 'static,
     ) -> Result<Self> {
         let power_pin = PinDriver::output(unsafe { AnyOutputPin::new(power_pin_num) })?;
-        let onewire_bus = OWDriver::new(
-            unsafe { AnyIOPin::new(data_pin_num) },
-            rmt_channel,
-        )?;
+        let onewire_bus = OWDriver::new(unsafe { AnyIOPin::new(data_pin_num) }, rmt_channel)?;
 
         Ok(Self {
             power_pin,
@@ -85,7 +81,11 @@ impl TempSensor {
                         a
                     }
                     Err(e) => {
-                        warn!("DS18B20 search failed (attempt {}/{}): {e}", attempt + 1, MAX_RETRIES);
+                        warn!(
+                            "DS18B20 search failed (attempt {}/{}): {e}",
+                            attempt + 1,
+                            MAX_RETRIES
+                        );
                         last_err = e;
                         continue;
                     }
@@ -94,7 +94,11 @@ impl TempSensor {
 
             // 温度変換コマンド送信
             if let Err(e) = self.onewire_bus.reset() {
-                warn!("1-Wire reset failed (attempt {}/{}): {e}", attempt + 1, MAX_RETRIES);
+                warn!(
+                    "1-Wire reset failed (attempt {}/{}): {e}",
+                    attempt + 1,
+                    MAX_RETRIES
+                );
                 last_err = e;
                 continue;
             }
@@ -103,7 +107,11 @@ impl TempSensor {
             buf[1..9].copy_from_slice(&addr.address().to_le_bytes());
             buf[9] = 0x44; // ConvertTemp
             if let Err(e) = self.onewire_bus.write(&buf) {
-                warn!("ConvertTemp failed (attempt {}/{}): {e}", attempt + 1, MAX_RETRIES);
+                warn!(
+                    "ConvertTemp failed (attempt {}/{}): {e}",
+                    attempt + 1,
+                    MAX_RETRIES
+                );
                 last_err = e;
                 continue;
             }
@@ -111,24 +119,36 @@ impl TempSensor {
 
             // Scratchpad読み出し
             if let Err(e) = self.onewire_bus.reset() {
-                warn!("1-Wire reset failed (attempt {}/{}): {e}", attempt + 1, MAX_RETRIES);
+                warn!(
+                    "1-Wire reset failed (attempt {}/{}): {e}",
+                    attempt + 1,
+                    MAX_RETRIES
+                );
                 last_err = e;
                 continue;
             }
             buf[9] = 0xBE; // ReadScratchpad
             if let Err(e) = self.onewire_bus.write(&buf) {
-                warn!("ReadScratch failed (attempt {}/{}): {e}", attempt + 1, MAX_RETRIES);
+                warn!(
+                    "ReadScratch failed (attempt {}/{}): {e}",
+                    attempt + 1,
+                    MAX_RETRIES
+                );
                 last_err = e;
                 continue;
             }
             let mut scratch = [0u8; 9];
             if let Err(e) = self.onewire_bus.read(&mut scratch) {
-                warn!("Scratchpad read failed (attempt {}/{}): {e}", attempt + 1, MAX_RETRIES);
+                warn!(
+                    "Scratchpad read failed (attempt {}/{}): {e}",
+                    attempt + 1,
+                    MAX_RETRIES
+                );
                 last_err = e;
                 continue;
             }
 
-            // CRC検証: DS18B20 scratchpad[8] は scratchpad[0..8] のCRC
+            // CRC検証: scratchpad の先頭 8 バイト (byte 0〜7) の CRC が byte[8] と一致すること
             if compute_crc8(&scratch[0..8]) != scratch[8] {
                 warn!(
                     "DS18B20 CRC mismatch on attempt {}/{}: scratch={:02X?}",

--- a/src/temp_sensor/temp_sensor.rs
+++ b/src/temp_sensor/temp_sensor.rs
@@ -181,7 +181,9 @@ impl TempSensor {
             return Ok(temp);
         }
 
-        let _ = self.power_pin.set_low();
+        if let Err(e) = self.power_pin.set_low() {
+            warn!("Failed to power down DS18B20 after all retries: {e}");
+        }
         Err(last_err)
     }
 }

--- a/src/temp_sensor/temp_sensor.rs
+++ b/src/temp_sensor/temp_sensor.rs
@@ -85,7 +85,7 @@ impl TempSensor {
                         a
                     }
                     Err(e) => {
-                        warn!("DS18B20 search failed (attempt {}/{})", attempt + 1, MAX_RETRIES);
+                        warn!("DS18B20 search failed (attempt {}/{}): {e}", attempt + 1, MAX_RETRIES);
                         last_err = e;
                         continue;
                     }
@@ -94,7 +94,7 @@ impl TempSensor {
 
             // 温度変換コマンド送信
             if let Err(e) = self.onewire_bus.reset() {
-                warn!("1-Wire reset failed (attempt {}/{})", attempt + 1, MAX_RETRIES);
+                warn!("1-Wire reset failed (attempt {}/{}): {e}", attempt + 1, MAX_RETRIES);
                 last_err = e;
                 continue;
             }
@@ -103,7 +103,7 @@ impl TempSensor {
             buf[1..9].copy_from_slice(&addr.address().to_le_bytes());
             buf[9] = 0x44; // ConvertTemp
             if let Err(e) = self.onewire_bus.write(&buf) {
-                warn!("ConvertTemp failed (attempt {}/{})", attempt + 1, MAX_RETRIES);
+                warn!("ConvertTemp failed (attempt {}/{}): {e}", attempt + 1, MAX_RETRIES);
                 last_err = e;
                 continue;
             }
@@ -111,19 +111,19 @@ impl TempSensor {
 
             // Scratchpad読み出し
             if let Err(e) = self.onewire_bus.reset() {
-                warn!("1-Wire reset failed (attempt {}/{})", attempt + 1, MAX_RETRIES);
+                warn!("1-Wire reset failed (attempt {}/{}): {e}", attempt + 1, MAX_RETRIES);
                 last_err = e;
                 continue;
             }
             buf[9] = 0xBE; // ReadScratchpad
             if let Err(e) = self.onewire_bus.write(&buf) {
-                warn!("ReadScratch failed (attempt {}/{})", attempt + 1, MAX_RETRIES);
+                warn!("ReadScratch failed (attempt {}/{}): {e}", attempt + 1, MAX_RETRIES);
                 last_err = e;
                 continue;
             }
             let mut scratch = [0u8; 9];
             if let Err(e) = self.onewire_bus.read(&mut scratch) {
-                warn!("Scratchpad read failed (attempt {}/{})", attempt + 1, MAX_RETRIES);
+                warn!("Scratchpad read failed (attempt {}/{}): {e}", attempt + 1, MAX_RETRIES);
                 last_err = e;
                 continue;
             }


### PR DESCRIPTION
## Summary

- Add Dallas 1-Wire CRC-8 (`compute_crc8`) to `logic.rs` to verify DS18B20 scratchpad integrity
- Add 85.0°C power-on-reset (POR) detection: treat it as a retriable error
- Retry up to 3 times, power-cycling the sensor between attempts and forcing device re-search on each retry

## Root cause (issue #4)

DS18B20 returns 85.0°C (POR default) when the conversion command is not received or power is unstable. Without CRC verification there is no way to distinguish a valid 85°C reading from a POR glitch; without retry there is no recovery path.

## Test plan

- [x] Host-side unit tests for `compute_crc8`: empty input, CRC-appended-gives-zero property, corrupt-data detection, known-value vectors
- [x] `cargo test --target aarch64-apple-darwin` → 7 tests, all pass
- [ ] Flash to XIAO ESP32-S3 with `use_deep_sleep = true` and verify no 85°C spikes in InfluxDB

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)